### PR TITLE
enable additional visibility setting (hide_output)

### DIFF
--- a/util.py
+++ b/util.py
@@ -10,17 +10,21 @@ def make_test_output(test_name=None, score=0, max_score=0, output="", visibility
     Return a dictionary representing results of a test.
     Fields are valid Gradescope autograder JSON.
     """
-    output = {
+    o = {
         "score": score,
         "max_score": max_score,
         "output": output
     }
     if visibility:
-        output["visibility"] = visibility
+        if visibility == "hide_message":
+            o["visibility"] = "visible"
+            o["output"] = ""
+        else:
+            o["visibility"] = visibility
     if test_name:
-        output["name"] = test_name
+        o["name"] = test_name
 
-    return output
+    return o
 
 def format_to_string(obj):
     """

--- a/util.py
+++ b/util.py
@@ -10,21 +10,21 @@ def make_test_output(test_name=None, score=0, max_score=0, output="", visibility
     Return a dictionary representing results of a test.
     Fields are valid Gradescope autograder JSON.
     """
-    o = {
+    result = {
         "score": score,
         "max_score": max_score,
         "output": output
     }
     if visibility:
         if visibility == "hide_message":
-            o["visibility"] = "visible"
-            o["output"] = ""
+            result["visibility"] = "visible"
+            result["output"] = ""
         else:
-            o["visibility"] = visibility
+            result["visibility"] = visibility
     if test_name:
-        o["name"] = test_name
+        result["name"] = test_name
 
-    return o
+    return result
 
 def format_to_string(obj):
     """


### PR DESCRIPTION
allow students to immediately see score but not any diff messages